### PR TITLE
Add actual error message when a server cannot be reached.

### DIFF
--- a/src/me/snov/newrelic/elasticsearch/ElasticsearchAgent.java
+++ b/src/me/snov/newrelic/elasticsearch/ElasticsearchAgent.java
@@ -47,7 +47,7 @@ public class ElasticsearchAgent extends Agent implements AgentInterface {
             throw new ConfigurationException("URL could not be parsed", e);
         } catch (IOException e) {
             throw new ConfigurationException(
-                String.format("Can't connect to elasticsearch at %s:%d", host, port),
+                String.format("Can't connect to elasticsearch at %s:%d. Error message was: %s", host, port, e.getMessage()),
                 e
             );
         }


### PR DESCRIPTION
I tried to use this plugin with a legacy elastic search installation which did not provide the `/_cluster/stats` endpoint.

When I started the plugin I only got the message with no further explaination

```
ERROR: Can't connect to elasticsearch at localhost:9200
```

With this change in case of failed connections you'll get the actual reason instead of a generic message, e.g.

```
ERROR: Can't connect to elasticsearch at localhost:9201. Error message was: Server returned HTTP response code: 400 for URL: http://localhost:9201/_cluster/stats
```
