### PR TITLE
Basic auth support for ES endpoints

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -117,7 +117,7 @@
             </manifest>
             <fileset dir="${main.build.classes.dir}"/>
             <zipfileset src="${sdk.jar}" />
-                <zipfileset src="${gson.jar}" />
+            <zipfileset src="${gson.jar}" />
             <zipfileset src="${commons-codec.jar}" />
         </jar>
     </target>

--- a/build.xml
+++ b/build.xml
@@ -27,15 +27,19 @@
     <property name="gson.jar" value="${lib.dir}/gson-2.3.1.jar" />
     <property name="junit.jar" value="${lib.dir}/junit-4.12.jar" />
     <property name="hamcrest.jar" value="${lib.dir}/hamcrest-core-1.3.jar" />
+    <property name="commons-codec.jar" value="${lib.dir}/commons-codec-1.10.jar" />
+
 
     <path id="classpath">
         <pathelement location="${sdk.jar}" />
         <pathelement location="${gson.jar}" />
+        <pathelement location="${commons-codec.jar}" />
     </path>
 
     <path id="classpath.test">
         <pathelement location="${sdk.jar}" />
         <pathelement location="${gson.jar}" />
+        <pathelement location="${commons-codec.jar}" />
         <pathelement location="${junit.jar}" />
     </path>
 

--- a/build.xml
+++ b/build.xml
@@ -117,7 +117,8 @@
             </manifest>
             <fileset dir="${main.build.classes.dir}"/>
             <zipfileset src="${sdk.jar}" />
-            <zipfileset src="${gson.jar}" />
+                <zipfileset src="${gson.jar}" />
+            <zipfileset src="${commons-codec.jar}" />
         </jar>
     </target>
 

--- a/config/plugin.template.json
+++ b/config/plugin.template.json
@@ -3,7 +3,9 @@
     {
       "host" : "localhost",
       "port" : 9200,
-      "_name": "Optional. By default loaded from elasticsearch. Rename to 'name' if you need to customize it"
+      "_name": "Optional. By default loaded from elasticsearch. Rename to 'name' if you need to customize it",
+      "username": "Optional. Basic Auth username",
+      "password": "Optional. Basic Auth password"
     }
   ]
 }

--- a/ivy.xml
+++ b/ivy.xml
@@ -4,6 +4,7 @@
         <dependency org="com.google.code.gson" name="gson" rev="2.3.1" />
         <dependency org="junit" name="junit" rev="4.12" />
         <dependency org="org.hamcrest" name="hamcrest-all" rev="1.3" />
+        <dependency org="commons-codec" name="commons-codec" rev="1.10"/>
     </dependencies>
 </ivy-module>
 

--- a/src/me/snov/newrelic/elasticsearch/ElasticsearchAgent.java
+++ b/src/me/snov/newrelic/elasticsearch/ElasticsearchAgent.java
@@ -33,12 +33,12 @@ public class ElasticsearchAgent extends Agent implements AgentInterface {
     /**
      * Constructor for Elastisearch Agent
      */
-    public ElasticsearchAgent(String host, Integer port, String name) throws ConfigurationException {
+    public ElasticsearchAgent(String host, Integer port, String name, String username, String password) throws ConfigurationException {
         super(GUID, VERSION);
         try {
             logger = Logger.getLogger(ElasticsearchAgent.class);
-            clusterStatsParser = new ClusterStatsParser(host, port);
-            nodesStatsParser = new NodesStatsParser(host, port);
+            clusterStatsParser = new ClusterStatsParser(host, port, username, password);
+            nodesStatsParser = new NodesStatsParser(host, port, username, password);
             clusterStatsService = new ClusterStatsService();
             clusterName = (name != null && name.length() > 0)
                 ? name

--- a/src/me/snov/newrelic/elasticsearch/ElasticsearchAgentFactory.java
+++ b/src/me/snov/newrelic/elasticsearch/ElasticsearchAgentFactory.java
@@ -17,6 +17,8 @@ public class ElasticsearchAgentFactory extends AgentFactory {
     @Override
     public Agent createConfiguredAgent(Map<String, Object> properties) throws ConfigurationException {
         String host = (String) properties.get("host");
+        String username = (String) properties.get("username");
+        String password = (String) properties.get("password");
         Long port = (Long) properties.get("port");
         String name = getClusterName(properties);
 
@@ -24,6 +26,6 @@ public class ElasticsearchAgentFactory extends AgentFactory {
             throw new ConfigurationException("'name' and 'host' cannot be null. Do you have a 'config/plugin.json' file?");
         }
 
-        return new ElasticsearchAgent(host, port.intValue(), name);
+        return new ElasticsearchAgent(host, port.intValue(), name, username, password);
     }
 }

--- a/src/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParser.java
+++ b/src/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParser.java
@@ -10,10 +10,10 @@ public class ClusterStatsParser extends AbstractParser<ClusterStats> {
     private static final String URL_CLUSTER_STATS = "/_cluster/stats";
 
     public ClusterStatsParser() {
-        super(ClusterStats.class, null);
+        super(ClusterStats.class, null, null, null);
     }
 
-    public ClusterStatsParser(String host, Integer port) throws MalformedURLException {
-        super(ClusterStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS));
+    public ClusterStatsParser(String host, Integer port, String username, String password) throws MalformedURLException {
+        super(ClusterStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS), username, password);
     }
 }

--- a/src/me/snov/newrelic/elasticsearch/parsers/NodesStatsParser.java
+++ b/src/me/snov/newrelic/elasticsearch/parsers/NodesStatsParser.java
@@ -10,10 +10,10 @@ public class NodesStatsParser extends AbstractParser<NodesStats> {
     private static final String URL_CLUSTER_STATS = "/_nodes/stats";
 
     public NodesStatsParser() {
-        super(NodesStats.class, null);
+        super(NodesStats.class, null, null, null);
     }
 
-    public NodesStatsParser(String host, Integer port) throws MalformedURLException {
-        super(NodesStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS));
+    public NodesStatsParser(String host, Integer port, String username, String password) throws MalformedURLException {
+        super(NodesStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS), username, password);
     }
 }


### PR DESCRIPTION
simple addition to support basic authentication headers in the requests to elastic search.

resolves #10 
