### PR TITLE
Adds status metrics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.6.1'
     compile 'commons-codec:commons-codec:1.10'
     testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:2.0.44-beta'
 }
 
 task copyTestResources(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.6.1'
     compile 'commons-codec:commons-codec:1.10'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.0.44-beta'
+    testCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 task copyTestResources(type: Copy) {

--- a/src/main/java/me/snov/newrelic/elasticsearch/ElasticsearchAgent.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/ElasticsearchAgent.java
@@ -1,18 +1,14 @@
 package me.snov.newrelic.elasticsearch;
 
 import com.newrelic.metrics.publish.Agent;
-import com.newrelic.metrics.publish.configuration.ConfigurationException;
 import com.newrelic.metrics.publish.util.Logger;
-
 import me.snov.newrelic.elasticsearch.interfaces.AgentInterface;
 import me.snov.newrelic.elasticsearch.parsers.ClusterStatsParser;
 import me.snov.newrelic.elasticsearch.parsers.NodesStatsParser;
+import me.snov.newrelic.elasticsearch.reporters.ClusterStatsReporter;
 import me.snov.newrelic.elasticsearch.reporters.NodesStatsReporter;
-import me.snov.newrelic.elasticsearch.responses.ClusterStats;
-import me.snov.newrelic.elasticsearch.services.*;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 
 /**
  * Agent for Elasticsearch cluster
@@ -23,45 +19,17 @@ public class ElasticsearchAgent extends Agent implements AgentInterface {
     private static final String VERSION = "2.1.1";
 
     private final String clusterName;
-    private final ClusterStatsParser clusterStatsParser;
-    private final ClusterStatsService clusterStatsService;
-    private final NodesStatsParser nodesStatsParser;
     private final Logger logger;
 
+    private ClusterStatsParser clusterStatsParser;
+    private ClusterStatsReporter clusterStatsReporter;
+    private NodesStatsParser nodesStatsParser;
     private NodesStatsReporter nodesStatsReporter;
 
-    /**
-     * Constructor for Elastisearch Agent
-     */
-    public ElasticsearchAgent(String host, Integer port, String name, String username, String password) throws ConfigurationException {
+    public ElasticsearchAgent(String clusterName) {
         super(GUID, VERSION);
-        try {
-            logger = Logger.getLogger(ElasticsearchAgent.class);
-            clusterStatsParser = new ClusterStatsParser(host, port, username, password);
-            nodesStatsParser = new NodesStatsParser(host, port, username, password);
-            clusterStatsService = new ClusterStatsService();
-            clusterName = (name != null && name.length() > 0)
-                ? name
-                : getClusterName();
-        } catch (MalformedURLException e) {
-            throw new ConfigurationException("URL could not be parsed", e);
-        } catch (IOException e) {
-            throw new ConfigurationException(
-                String.format("Can't connect to elasticsearch at %s:%d. Error message was: %s", host, port, e.getMessage()),
-                e
-            );
-        }
-    }
-
-    private String getClusterName() throws IOException {
-        return clusterStatsParser.request().cluster_name;
-    }
-
-    private void initReporters()
-    {
-        if (nodesStatsReporter == null) {
-            nodesStatsReporter = new NodesStatsReporter(this);
-        }
+        this.clusterName = clusterName;
+        this.logger = Logger.getLogger(ElasticsearchAgent.class);
     }
 
     @Override
@@ -72,48 +40,18 @@ public class ElasticsearchAgent extends Agent implements AgentInterface {
     @Override
     public void pollCycle() {
         try {
-            initReporters();
-            reportClusterStats(clusterStatsParser.request());
+            clusterStatsReporter.reportClusterStats(clusterStatsParser.request());
             nodesStatsReporter.reportNodesStats(nodesStatsParser.request());
         } catch (IOException e) {
-            logger.error(e.getMessage());
+            logger.error("Unable to perform poll cycle", e);
         }
     }
 
-    private void reportClusterStats(ClusterStats clusterStats) {
-
-        /******************* Cluster *******************/
-
-        // Component/V1/ClusterStats/Indices/Docs/*
-        reportMetric("V1/ClusterStats/Indices/Docs/Count", "documents", clusterStats.indices.docs.count);
-        reportMetric("V1/ClusterStats/Indices/Docs/Deleted", "documents", clusterStats.indices.docs.deleted);
-
-        // Nodes (table)
-        // Component/V1/ClusterStats/Nodes/Count/*
-        reportMetric("V1/ClusterStats/Nodes/Count/Total", "nodes", clusterStats.nodes.count.total);
-        reportMetric("V1/ClusterStats/Nodes/Count/Master and data", "nodes", clusterStats.nodes.count.master_data);
-        reportMetric("V1/ClusterStats/Nodes/Count/Master only", "nodes", clusterStats.nodes.count.master_only);
-        reportMetric("V1/ClusterStats/Nodes/Count/Data only", "nodes", clusterStats.nodes.count.data_only);
-        reportMetric("V1/ClusterStats/Nodes/Count/Client", "nodes", clusterStats.nodes.count.client);
-
-        // Indices and Shards (table)
-        // Component/V1/ClusterStats/Indices/Group1/*
-        reportMetric("V1/ClusterStats/Indices/Group1/Indices", "indices", clusterStats.indices.count);
-        reportMetric("V1/ClusterStats/Indices/Group1/Shards", "shards", clusterStats.indices.shards.total);
-        reportMetric("V1/ClusterStats/Indices/Group1/Primaries", "shards", clusterStats.indices.shards.total);
-        reportMetric("V1/ClusterStats/Indices/Group1/Replication", "shards", clusterStats.indices.shards.replication);
-
-        // Component/V1/ClusterStats/Indices/Segments/Count
-        reportMetric("V1/ClusterStats/Indices/Segments/Count", "segments", clusterStats.indices.segments.count);
-
-        // Component/V1/ClusterStats/Indices/Store/Size
-        reportMetric("V1/ClusterStats/Indices/Store/Size", "bytes", clusterStats.indices.store.size_in_bytes);
-
-
-        /******************* Summary *******************/
-
-        // Component/V1/ClusterStats/NumberOfVersionsInCluster
-        reportMetric("V1/ClusterStats/NumberOfVersionsInCluster", "versions",
-            clusterStatsService.getNumberOfVersionsInCluster(clusterStats));
+    public void configure(ClusterStatsParser clusterStatsParser, ClusterStatsReporter clusterStatsReporter,
+                          NodesStatsParser nodesStatsParser, NodesStatsReporter nodesStatsReporter) {
+        this.clusterStatsParser = clusterStatsParser;
+        this.clusterStatsReporter = clusterStatsReporter;
+        this.nodesStatsParser = nodesStatsParser;
+        this.nodesStatsReporter = nodesStatsReporter;
     }
 }

--- a/src/main/java/me/snov/newrelic/elasticsearch/interfaces/AgentInterface.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/interfaces/AgentInterface.java
@@ -1,5 +1,5 @@
 package me.snov.newrelic.elasticsearch.interfaces;
 
 public interface AgentInterface {
-    public void reportMetric(String metricName, String units, Number value);
+    void reportMetric(String metricName, String units, Number value);
 }

--- a/src/main/java/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParser.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParser.java
@@ -13,7 +13,7 @@ public class ClusterStatsParser extends AbstractParser<ClusterStats> {
         super(ClusterStats.class, null, null, null);
     }
 
-    public ClusterStatsParser(String host, Integer port, String username, String password) throws MalformedURLException {
+    public ClusterStatsParser(String host, int port, String username, String password) throws MalformedURLException {
         super(ClusterStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS), username, password);
     }
 }

--- a/src/main/java/me/snov/newrelic/elasticsearch/parsers/NodesStatsParser.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/parsers/NodesStatsParser.java
@@ -13,7 +13,7 @@ public class NodesStatsParser extends AbstractParser<NodesStats> {
         super(NodesStats.class, null, null, null);
     }
 
-    public NodesStatsParser(String host, Integer port, String username, String password) throws MalformedURLException {
+    public NodesStatsParser(String host, int port, String username, String password) throws MalformedURLException {
         super(NodesStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS), username, password);
     }
 }

--- a/src/main/java/me/snov/newrelic/elasticsearch/reporters/ClusterStatsReporter.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/reporters/ClusterStatsReporter.java
@@ -1,0 +1,58 @@
+package me.snov.newrelic.elasticsearch.reporters;
+
+import me.snov.newrelic.elasticsearch.interfaces.AgentInterface;
+import me.snov.newrelic.elasticsearch.responses.ClusterStats;
+import me.snov.newrelic.elasticsearch.services.ClusterStatsService;
+
+public class ClusterStatsReporter {
+
+    private final AgentInterface agent;
+    private final ClusterStatsService clusterStatsService;
+
+    public ClusterStatsReporter(AgentInterface agent) {
+        this.agent = agent;
+        this.clusterStatsService = new ClusterStatsService();
+    }
+
+    public void reportClusterStats(ClusterStats clusterStats) {
+        // Cluster status (we represent unhealthy states as an int to allow alerting on values > 0)
+        agent.reportMetric("V1/ClusterStats/Status/IsYellow", "bool", asInt(clusterStatsService.isYellow(clusterStats)));
+        agent.reportMetric("V1/ClusterStats/Status/IsRed", "bool", asInt(clusterStatsService.isRed(clusterStats)));
+
+        // Component/V1/ClusterStats/Indices/Docs/*
+        agent.reportMetric("V1/ClusterStats/Indices/Docs/Count", "documents", clusterStats.indices.docs.count);
+        agent.reportMetric("V1/ClusterStats/Indices/Docs/Deleted", "documents", clusterStats.indices.docs.deleted);
+
+        // Nodes (table)
+        // Component/V1/ClusterStats/Nodes/Count/*
+        agent.reportMetric("V1/ClusterStats/Nodes/Count/Total", "nodes", clusterStats.nodes.count.total);
+        agent.reportMetric("V1/ClusterStats/Nodes/Count/Master and data", "nodes", clusterStats.nodes.count.master_data);
+        agent.reportMetric("V1/ClusterStats/Nodes/Count/Master only", "nodes", clusterStats.nodes.count.master_only);
+        agent.reportMetric("V1/ClusterStats/Nodes/Count/Data only", "nodes", clusterStats.nodes.count.data_only);
+        agent.reportMetric("V1/ClusterStats/Nodes/Count/Client", "nodes", clusterStats.nodes.count.client);
+
+        // Indices and Shards (table)
+        // Component/V1/ClusterStats/Indices/Group1/*
+        agent.reportMetric("V1/ClusterStats/Indices/Group1/Indices", "indices", clusterStats.indices.count);
+        agent.reportMetric("V1/ClusterStats/Indices/Group1/Shards", "shards", clusterStats.indices.shards.total);
+        agent.reportMetric("V1/ClusterStats/Indices/Group1/Primaries", "shards", clusterStats.indices.shards.total);
+        agent.reportMetric("V1/ClusterStats/Indices/Group1/Replication", "shards", clusterStats.indices.shards.replication);
+
+        // Component/V1/ClusterStats/Indices/Segments/Count
+        agent.reportMetric("V1/ClusterStats/Indices/Segments/Count", "segments", clusterStats.indices.segments.count);
+
+        // Component/V1/ClusterStats/Indices/Store/Size
+        agent.reportMetric("V1/ClusterStats/Indices/Store/Size", "bytes", clusterStats.indices.store.size_in_bytes);
+
+
+        /******************* Summary *******************/
+
+        // Component/V1/ClusterStats/NumberOfVersionsInCluster
+        agent.reportMetric("V1/ClusterStats/NumberOfVersionsInCluster", "versions",
+                clusterStatsService.getNumberOfVersionsInCluster(clusterStats));
+    }
+
+    private int asInt(boolean value) {
+        return value ? 1 : 0;
+    }
+}

--- a/src/main/java/me/snov/newrelic/elasticsearch/services/ClusterStatsService.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/services/ClusterStatsService.java
@@ -24,4 +24,12 @@ public class ClusterStatsService {
             ? 0
             : getNumberOfVersions(clusterStats.nodes.versions);
     }
+
+    public boolean isYellow(ClusterStats clusterStats) {
+        return "yellow".equals(clusterStats.status);
+    }
+
+    public boolean isRed(ClusterStats clusterStats) {
+        return "red".equals(clusterStats.status);
+    }
 }

--- a/src/test/java/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParserTest.java
+++ b/src/test/java/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParserTest.java
@@ -1,13 +1,12 @@
-package me.snov.newrelic.elasticsearch.services;
+package me.snov.newrelic.elasticsearch.parsers;
 
-import me.snov.newrelic.elasticsearch.parsers.ClusterStatsParser;
 import me.snov.newrelic.elasticsearch.responses.ClusterStats;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class ClusterStatsParserTest {
 
@@ -27,10 +26,11 @@ public class ClusterStatsParserTest {
     }
 
     @Test
-    public void testV151() throws Exception {
-        ClusterStats clusterStats = parseJson("/resources/cluster_stats_1.5.1.json");
+    public void testV211() throws Exception {
+        ClusterStats clusterStats = parseJson("/resources/cluster_stats_2.1.1.json");
         assertEquals("elasticsearch", clusterStats.cluster_name);
-        assertEquals(1l, clusterStats.nodes.count.total.longValue());
+        assertEquals("green", clusterStats.status);
+        assertEquals(2L, clusterStats.nodes.count.total.longValue());
         assertEquals(1, clusterStats.nodes.versions.size());
     }
 
@@ -38,7 +38,15 @@ public class ClusterStatsParserTest {
     public void testV210() throws Exception {
         ClusterStats clusterStats = parseJson("/resources/cluster_stats_2.1.0.json");
         assertEquals("elasticsearch", clusterStats.cluster_name);
-        assertEquals(1l, clusterStats.nodes.count.total.longValue());
+        assertEquals(1L, clusterStats.nodes.count.total.longValue());
+        assertEquals(1, clusterStats.nodes.versions.size());
+    }
+
+    @Test
+    public void testV151() throws Exception {
+        ClusterStats clusterStats = parseJson("/resources/cluster_stats_1.5.1.json");
+        assertEquals("elasticsearch", clusterStats.cluster_name);
+        assertEquals(1L, clusterStats.nodes.count.total.longValue());
         assertEquals(1, clusterStats.nodes.versions.size());
     }
 
@@ -46,15 +54,15 @@ public class ClusterStatsParserTest {
     public void testV142() throws Exception {
         ClusterStats clusterStats = parseJson("/resources/cluster_stats_1.4.2.json");
         assertEquals("elasticsearch_snov", clusterStats.cluster_name);
-        assertEquals(1601396l, clusterStats.indices.segments.memory_in_bytes.longValue());
-        assertEquals(1l, clusterStats.nodes.count.total.longValue());
+        assertEquals(1601396L, clusterStats.indices.segments.memory_in_bytes.longValue());
+        assertEquals(1L, clusterStats.nodes.count.total.longValue());
     }
 
     @Test
     public void testV134() throws Exception {
         ClusterStats clusterStats = parseJson("/resources/cluster_stats_1.3.4.json");
         assertEquals("esearch-testcluster", clusterStats.cluster_name);
-        assertEquals(3l, clusterStats.nodes.count.total.longValue());
+        assertEquals(3L, clusterStats.nodes.count.total.longValue());
         assertEquals(1, clusterStats.nodes.versions.size());
     }
 
@@ -62,7 +70,7 @@ public class ClusterStatsParserTest {
     public void testV090() throws Exception {
         ClusterStats clusterStats = parseJson("/resources/cluster_stats_0.90.12.json");
         assertEquals("elasticsearch", clusterStats.cluster_name);
-        assertEquals(1l, clusterStats.nodes.count.total.longValue());
+        assertEquals(1L, clusterStats.nodes.count.total.longValue());
         assertEquals(1, clusterStats.nodes.versions.size());
     }
 }

--- a/src/test/java/me/snov/newrelic/elasticsearch/parsers/NodesStatsParserTest.java
+++ b/src/test/java/me/snov/newrelic/elasticsearch/parsers/NodesStatsParserTest.java
@@ -1,6 +1,5 @@
-package me.snov.newrelic.elasticsearch.services;
+package me.snov.newrelic.elasticsearch.parsers;
 
-import me.snov.newrelic.elasticsearch.parsers.NodesStatsParser;
 import me.snov.newrelic.elasticsearch.responses.NodesStats;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,6 +7,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 
 public class NodesStatsParserTest {
@@ -30,10 +30,18 @@ public class NodesStatsParserTest {
     }
 
     @Test
+    public void testV211() throws Exception {
+        NodesStats nodesStats = parseJson("/resources/nodes_stats_2.1.1.json");
+        assertThat(nodesStats.nodes.size(), is(2));
+        assertThat(nodesStats.nodes.get("nfxaGjN8QLqmru6bA2RoxQ").name, is("Everyman"));
+        assertThat(nodesStats.nodes.get("88CFbaIcRLql01dB6I0FCw").name, is("Foolkiller"));
+    }
+
+    @Test
     public void testV134() throws Exception {
         NodesStats nodesStats = parseJson("/resources/nodes_stats_1.3.4.json");
         assertEquals(3, nodesStats.nodes.size());
-        assertEquals(200l, nodesStats.nodes.get("lNFk2gshR5GVDPmRrnDyoA")
+        assertEquals(200L, nodesStats.nodes.get("lNFk2gshR5GVDPmRrnDyoA")
             .jvm.gc.collectors.young.collection_time_in_millis.longValue());
     }
 }

--- a/src/test/java/me/snov/newrelic/elasticsearch/reporters/ClusterStatsReporterTest.java
+++ b/src/test/java/me/snov/newrelic/elasticsearch/reporters/ClusterStatsReporterTest.java
@@ -1,0 +1,56 @@
+package me.snov.newrelic.elasticsearch.reporters;
+
+import me.snov.newrelic.elasticsearch.interfaces.AgentInterface;
+import me.snov.newrelic.elasticsearch.parsers.ClusterStatsParser;
+import me.snov.newrelic.elasticsearch.responses.ClusterStats;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterStatsReporterTest {
+
+    private ClusterStatsReporter clusterStatsReporter;
+    private ClusterStats clusterStats;
+    @Mock private AgentInterface agent;
+
+    @Before
+    public void setUp() throws Exception {
+        clusterStatsReporter = new ClusterStatsReporter(agent);
+        clusterStats = new ClusterStatsParser().parse(getClass().getResourceAsStream("/resources/cluster_stats_2.1.1.json"));
+    }
+
+    @Test
+    public void shouldReportGreenStatusCorrectly() throws Exception {
+        clusterStats.status = "green";
+
+        clusterStatsReporter.reportClusterStats(clusterStats);
+
+        verify(agent).reportMetric("V1/ClusterStats/Status/IsYellow", "bool", 0);
+        verify(agent).reportMetric("V1/ClusterStats/Status/IsRed", "bool", 0);
+    }
+
+    @Test
+    public void shouldReportRedStatusCorrectly() throws Exception {
+        clusterStats.status = "red";
+
+        clusterStatsReporter.reportClusterStats(clusterStats);
+
+        verify(agent).reportMetric("V1/ClusterStats/Status/IsYellow", "bool", 0);
+        verify(agent).reportMetric("V1/ClusterStats/Status/IsRed", "bool", 1);
+    }
+
+    @Test
+    public void shouldReportYellowStatusCorrectly() throws Exception {
+        clusterStats.status = "yellow";
+
+        clusterStatsReporter.reportClusterStats(clusterStats);
+
+        verify(agent).reportMetric("V1/ClusterStats/Status/IsYellow", "bool", 1);
+        verify(agent).reportMetric("V1/ClusterStats/Status/IsRed", "bool", 0);
+    }
+}

--- a/src/test/java/me/snov/newrelic/elasticsearch/reporters/MockAgent.java
+++ b/src/test/java/me/snov/newrelic/elasticsearch/reporters/MockAgent.java
@@ -1,4 +1,4 @@
-package me.snov.newrelic.elasticsearch.services;
+package me.snov.newrelic.elasticsearch.reporters;
 
 import me.snov.newrelic.elasticsearch.interfaces.AgentInterface;
 

--- a/src/test/java/me/snov/newrelic/elasticsearch/reporters/NodesStatsReporterTest.java
+++ b/src/test/java/me/snov/newrelic/elasticsearch/reporters/NodesStatsReporterTest.java
@@ -1,21 +1,17 @@
-package me.snov.newrelic.elasticsearch.services;
+package me.snov.newrelic.elasticsearch.reporters;
 
 import me.snov.newrelic.elasticsearch.parsers.NodesStatsParser;
-import me.snov.newrelic.elasticsearch.reporters.NodesStatsReporter;
 import me.snov.newrelic.elasticsearch.responses.NodesStats;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public class NodesStatsReporterTest {
 
-    private static final String nodesStatsUrl = "http://localhost:9200/_nodes/stats"; 
-    
     private MockAgent agent;
     private NodesStatsParser parser;
     private NodesStatsReporter reporter;
@@ -37,10 +33,6 @@ public class NodesStatsReporterTest {
     
     private NodesStats parseJsonFromFile(String path) throws IOException {
         return parseJson(getClass().getResourceAsStream(path));
-    }
-    
-    private NodesStats parseJsonFromUrl(String url) throws IOException {
-        return parseJson(new URL(url).openConnection().getInputStream());
     }
 
     @Test
@@ -79,8 +71,8 @@ public class NodesStatsReporterTest {
     }
 
     @Test
-    public void testReportNodesStatsV210() throws Exception {
-        NodesStats nodesStats = parseJsonFromUrl(nodesStatsUrl);
+    public void testReportNodesStatsV211() throws Exception {
+        NodesStats nodesStats = parseJsonFromFile("/resources/nodes_stats_2.1.1.json");
         reporter.reportNodesStats(nodesStats);
         assertTrue("Number of reported metrics > 0", agent.getReportedMetricsCount() > 0);
     }

--- a/src/test/resources/cluster_stats_2.1.1.json
+++ b/src/test/resources/cluster_stats_2.1.1.json
@@ -1,0 +1,103 @@
+{
+  "timestamp" : 1459467560871,
+  "cluster_name" : "elasticsearch",
+  "status" : "green",
+  "indices" : {
+    "count" : 0,
+    "shards" : { },
+    "docs" : {
+      "count" : 0,
+      "deleted" : 0
+    },
+    "store" : {
+      "size_in_bytes" : 0,
+      "throttle_time_in_millis" : 0
+    },
+    "fielddata" : {
+      "memory_size_in_bytes" : 0,
+      "evictions" : 0
+    },
+    "query_cache" : {
+      "memory_size_in_bytes" : 0,
+      "total_count" : 0,
+      "hit_count" : 0,
+      "miss_count" : 0,
+      "cache_size" : 0,
+      "cache_count" : 0,
+      "evictions" : 0
+    },
+    "completion" : {
+      "size_in_bytes" : 0
+    },
+    "segments" : {
+      "count" : 0,
+      "memory_in_bytes" : 0,
+      "terms_memory_in_bytes" : 0,
+      "stored_fields_memory_in_bytes" : 0,
+      "term_vectors_memory_in_bytes" : 0,
+      "norms_memory_in_bytes" : 0,
+      "doc_values_memory_in_bytes" : 0,
+      "index_writer_memory_in_bytes" : 0,
+      "index_writer_max_memory_in_bytes" : 0,
+      "version_map_memory_in_bytes" : 0,
+      "fixed_bit_set_memory_in_bytes" : 0
+    },
+    "percolate" : {
+      "total" : 0,
+      "time_in_millis" : 0,
+      "current" : 0,
+      "memory_size_in_bytes" : -1,
+      "memory_size" : "-1b",
+      "queries" : 0
+    }
+  },
+  "nodes" : {
+    "count" : {
+      "total" : 2,
+      "master_only" : 0,
+      "data_only" : 0,
+      "master_data" : 2,
+      "client" : 0
+    },
+    "versions" : [ "2.1.1" ],
+    "os" : {
+      "available_processors" : 8,
+      "allocated_processors" : 8,
+      "mem" : {
+        "total_in_bytes" : 0
+      },
+      "names" : [ ]
+    },
+    "process" : {
+      "cpu" : {
+        "percent" : 0
+      },
+      "open_file_descriptors" : {
+        "min" : 258,
+        "max" : 259,
+        "avg" : 258
+      }
+    },
+    "jvm" : {
+      "max_uptime_in_millis" : 68119,
+      "versions" : [ {
+        "version" : "1.8.0_45",
+        "vm_name" : "Java HotSpot(TM) 64-Bit Server VM",
+        "vm_version" : "25.45-b02",
+        "vm_vendor" : "Oracle Corporation",
+        "count" : 2
+      } ],
+      "mem" : {
+        "heap_used_in_bytes" : 54635200,
+        "heap_max_in_bytes" : 2075918336
+      },
+      "threads" : 134
+    },
+    "fs" : {
+      "total_in_bytes" : 239063433216,
+      "free_in_bytes" : 9278623744,
+      "available_in_bytes" : 9016479744
+    },
+    "plugins" : [ ]
+  }
+}

--- a/src/test/resources/nodes_stats_2.1.1.json
+++ b/src/test/resources/nodes_stats_2.1.1.json
@@ -1,0 +1,824 @@
+{
+  "cluster_name" : "elasticsearch",
+  "nodes" : {
+    "nfxaGjN8QLqmru6bA2RoxQ" : {
+      "timestamp" : 1459467547006,
+      "name" : "Everyman",
+      "transport_address" : "127.0.0.1:9300",
+      "host" : "127.0.0.1",
+      "ip" : [ "127.0.0.1:9300", "NONE" ],
+      "indices" : {
+        "docs" : {
+          "count" : 0,
+          "deleted" : 0
+        },
+        "store" : {
+          "size_in_bytes" : 0,
+          "throttle_time_in_millis" : 0
+        },
+        "indexing" : {
+          "index_total" : 0,
+          "index_time_in_millis" : 0,
+          "index_current" : 0,
+          "index_failed" : 0,
+          "delete_total" : 0,
+          "delete_time_in_millis" : 0,
+          "delete_current" : 0,
+          "noop_update_total" : 0,
+          "is_throttled" : false,
+          "throttle_time_in_millis" : 0
+        },
+        "get" : {
+          "total" : 0,
+          "time_in_millis" : 0,
+          "exists_total" : 0,
+          "exists_time_in_millis" : 0,
+          "missing_total" : 0,
+          "missing_time_in_millis" : 0,
+          "current" : 0
+        },
+        "search" : {
+          "open_contexts" : 0,
+          "query_total" : 0,
+          "query_time_in_millis" : 0,
+          "query_current" : 0,
+          "fetch_total" : 0,
+          "fetch_time_in_millis" : 0,
+          "fetch_current" : 0,
+          "scroll_total" : 0,
+          "scroll_time_in_millis" : 0,
+          "scroll_current" : 0
+        },
+        "merges" : {
+          "current" : 0,
+          "current_docs" : 0,
+          "current_size_in_bytes" : 0,
+          "total" : 0,
+          "total_time_in_millis" : 0,
+          "total_docs" : 0,
+          "total_size_in_bytes" : 0,
+          "total_stopped_time_in_millis" : 0,
+          "total_throttled_time_in_millis" : 0,
+          "total_auto_throttle_in_bytes" : 0
+        },
+        "refresh" : {
+          "total" : 0,
+          "total_time_in_millis" : 0
+        },
+        "flush" : {
+          "total" : 0,
+          "total_time_in_millis" : 0
+        },
+        "warmer" : {
+          "current" : 0,
+          "total" : 0,
+          "total_time_in_millis" : 0
+        },
+        "query_cache" : {
+          "memory_size_in_bytes" : 0,
+          "total_count" : 0,
+          "hit_count" : 0,
+          "miss_count" : 0,
+          "cache_size" : 0,
+          "cache_count" : 0,
+          "evictions" : 0
+        },
+        "fielddata" : {
+          "memory_size_in_bytes" : 0,
+          "evictions" : 0
+        },
+        "percolate" : {
+          "total" : 0,
+          "time_in_millis" : 0,
+          "current" : 0,
+          "memory_size_in_bytes" : -1,
+          "memory_size" : "-1b",
+          "queries" : 0
+        },
+        "completion" : {
+          "size_in_bytes" : 0
+        },
+        "segments" : {
+          "count" : 0,
+          "memory_in_bytes" : 0,
+          "terms_memory_in_bytes" : 0,
+          "stored_fields_memory_in_bytes" : 0,
+          "term_vectors_memory_in_bytes" : 0,
+          "norms_memory_in_bytes" : 0,
+          "doc_values_memory_in_bytes" : 0,
+          "index_writer_memory_in_bytes" : 0,
+          "index_writer_max_memory_in_bytes" : 0,
+          "version_map_memory_in_bytes" : 0,
+          "fixed_bit_set_memory_in_bytes" : 0
+        },
+        "translog" : {
+          "operations" : 0,
+          "size_in_bytes" : 0
+        },
+        "suggest" : {
+          "total" : 0,
+          "time_in_millis" : 0,
+          "current" : 0
+        },
+        "request_cache" : {
+          "memory_size_in_bytes" : 0,
+          "evictions" : 0,
+          "hit_count" : 0,
+          "miss_count" : 0
+        },
+        "recovery" : {
+          "current_as_source" : 0,
+          "current_as_target" : 0,
+          "throttle_time_in_millis" : 0
+        }
+      },
+      "os" : {
+        "timestamp" : 1459467547006,
+        "load_average" : 2.67333984375,
+        "mem" : {
+          "total_in_bytes" : 17179869184,
+          "free_in_bytes" : 746844160,
+          "used_in_bytes" : 16433025024,
+          "free_percent" : 4,
+          "used_percent" : 96
+        },
+        "swap" : {
+          "total_in_bytes" : 1073741824,
+          "free_in_bytes" : 1073741824,
+          "used_in_bytes" : 0
+        }
+      },
+      "process" : {
+        "timestamp" : 1459467547006,
+        "open_file_descriptors" : 259,
+        "max_file_descriptors" : 10240,
+        "cpu" : {
+          "percent" : 0,
+          "total_in_millis" : 8677
+        },
+        "mem" : {
+          "total_virtual_in_bytes" : 5247422464
+        }
+      },
+      "jvm" : {
+        "timestamp" : 1459467547006,
+        "uptime_in_millis" : 54257,
+        "mem" : {
+          "heap_used_in_bytes" : 26313208,
+          "heap_used_percent" : 2,
+          "heap_committed_in_bytes" : 259522560,
+          "heap_max_in_bytes" : 1037959168,
+          "non_heap_used_in_bytes" : 42172864,
+          "non_heap_committed_in_bytes" : 43663360,
+          "pools" : {
+            "young" : {
+              "used_in_bytes" : 8736960,
+              "max_in_bytes" : 286326784,
+              "peak_used_in_bytes" : 71630848,
+              "peak_max_in_bytes" : 286326784
+            },
+            "survivor" : {
+              "used_in_bytes" : 8426272,
+              "max_in_bytes" : 35782656,
+              "peak_used_in_bytes" : 8912896,
+              "peak_max_in_bytes" : 35782656
+            },
+            "old" : {
+              "used_in_bytes" : 9149976,
+              "max_in_bytes" : 715849728,
+              "peak_used_in_bytes" : 9441008,
+              "peak_max_in_bytes" : 715849728
+            }
+          }
+        },
+        "threads" : {
+          "count" : 74,
+          "peak_count" : 77
+        },
+        "gc" : {
+          "collectors" : {
+            "young" : {
+              "collection_count" : 4,
+              "collection_time_in_millis" : 47
+            },
+            "old" : {
+              "collection_count" : 1,
+              "collection_time_in_millis" : 14
+            }
+          }
+        },
+        "buffer_pools" : {
+          "direct" : {
+            "count" : 69,
+            "used_in_bytes" : 10516294,
+            "total_capacity_in_bytes" : 10516294
+          },
+          "mapped" : {
+            "count" : 0,
+            "used_in_bytes" : 0,
+            "total_capacity_in_bytes" : 0
+          }
+        },
+        "classes" : {
+          "current_loaded_count" : 6138,
+          "total_loaded_count" : 6138,
+          "total_unloaded_count" : 0
+        }
+      },
+      "thread_pool" : {
+        "bulk" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "fetch_shard_started" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "fetch_shard_store" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "flush" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "force_merge" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "generic" : {
+          "threads" : 1,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 4,
+          "completed" : 39
+        },
+        "get" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "index" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "listener" : {
+          "threads" : 1,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 1,
+          "completed" : 1
+        },
+        "management" : {
+          "threads" : 2,
+          "queue" : 0,
+          "active" : 1,
+          "rejected" : 0,
+          "largest" : 2,
+          "completed" : 7
+        },
+        "percolate" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "refresh" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "search" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "snapshot" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "suggest" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "warmer" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        }
+      },
+      "fs" : {
+        "timestamp" : 1459467547006,
+        "total" : {
+          "total_in_bytes" : 239063433216,
+          "free_in_bytes" : 9278656512,
+          "available_in_bytes" : 9016512512
+        },
+        "data" : [ {
+          "path" : "/usr/local/var/elasticsearch/elasticsearch/nodes/0",
+          "mount" : "/ (/dev/disk0s2)",
+          "type" : "hfs",
+          "total_in_bytes" : 239063433216,
+          "free_in_bytes" : 9278656512,
+          "available_in_bytes" : 9016512512
+        } ]
+      },
+      "transport" : {
+        "server_open" : 13,
+        "rx_count" : 108,
+        "rx_size_in_bytes" : 11579,
+        "tx_count" : 109,
+        "tx_size_in_bytes" : 18989
+      },
+      "http" : {
+        "current_open" : 1,
+        "total_opened" : 2
+      },
+      "breakers" : {
+        "request" : {
+          "limit_size_in_bytes" : 415183667,
+          "limit_size" : "395.9mb",
+          "estimated_size_in_bytes" : 0,
+          "estimated_size" : "0b",
+          "overhead" : 1.0,
+          "tripped" : 0
+        },
+        "fielddata" : {
+          "limit_size_in_bytes" : 622775500,
+          "limit_size" : "593.9mb",
+          "estimated_size_in_bytes" : 0,
+          "estimated_size" : "0b",
+          "overhead" : 1.03,
+          "tripped" : 0
+        },
+        "parent" : {
+          "limit_size_in_bytes" : 726571417,
+          "limit_size" : "692.9mb",
+          "estimated_size_in_bytes" : 0,
+          "estimated_size" : "0b",
+          "overhead" : 1.0,
+          "tripped" : 0
+        }
+      },
+      "script" : {
+        "compilations" : 0,
+        "cache_evictions" : 0
+      }
+    },
+    "88CFbaIcRLql01dB6I0FCw" : {
+      "timestamp" : 1459467547007,
+      "name" : "Foolkiller",
+      "transport_address" : "127.0.0.1:9301",
+      "host" : "127.0.0.1",
+      "ip" : [ "127.0.0.1:9301", "NONE" ],
+      "indices" : {
+        "docs" : {
+          "count" : 0,
+          "deleted" : 0
+        },
+        "store" : {
+          "size_in_bytes" : 0,
+          "throttle_time_in_millis" : 0
+        },
+        "indexing" : {
+          "index_total" : 0,
+          "index_time_in_millis" : 0,
+          "index_current" : 0,
+          "index_failed" : 0,
+          "delete_total" : 0,
+          "delete_time_in_millis" : 0,
+          "delete_current" : 0,
+          "noop_update_total" : 0,
+          "is_throttled" : false,
+          "throttle_time_in_millis" : 0
+        },
+        "get" : {
+          "total" : 0,
+          "time_in_millis" : 0,
+          "exists_total" : 0,
+          "exists_time_in_millis" : 0,
+          "missing_total" : 0,
+          "missing_time_in_millis" : 0,
+          "current" : 0
+        },
+        "search" : {
+          "open_contexts" : 0,
+          "query_total" : 0,
+          "query_time_in_millis" : 0,
+          "query_current" : 0,
+          "fetch_total" : 0,
+          "fetch_time_in_millis" : 0,
+          "fetch_current" : 0,
+          "scroll_total" : 0,
+          "scroll_time_in_millis" : 0,
+          "scroll_current" : 0
+        },
+        "merges" : {
+          "current" : 0,
+          "current_docs" : 0,
+          "current_size_in_bytes" : 0,
+          "total" : 0,
+          "total_time_in_millis" : 0,
+          "total_docs" : 0,
+          "total_size_in_bytes" : 0,
+          "total_stopped_time_in_millis" : 0,
+          "total_throttled_time_in_millis" : 0,
+          "total_auto_throttle_in_bytes" : 0
+        },
+        "refresh" : {
+          "total" : 0,
+          "total_time_in_millis" : 0
+        },
+        "flush" : {
+          "total" : 0,
+          "total_time_in_millis" : 0
+        },
+        "warmer" : {
+          "current" : 0,
+          "total" : 0,
+          "total_time_in_millis" : 0
+        },
+        "query_cache" : {
+          "memory_size_in_bytes" : 0,
+          "total_count" : 0,
+          "hit_count" : 0,
+          "miss_count" : 0,
+          "cache_size" : 0,
+          "cache_count" : 0,
+          "evictions" : 0
+        },
+        "fielddata" : {
+          "memory_size_in_bytes" : 0,
+          "evictions" : 0
+        },
+        "percolate" : {
+          "total" : 0,
+          "time_in_millis" : 0,
+          "current" : 0,
+          "memory_size_in_bytes" : -1,
+          "memory_size" : "-1b",
+          "queries" : 0
+        },
+        "completion" : {
+          "size_in_bytes" : 0
+        },
+        "segments" : {
+          "count" : 0,
+          "memory_in_bytes" : 0,
+          "terms_memory_in_bytes" : 0,
+          "stored_fields_memory_in_bytes" : 0,
+          "term_vectors_memory_in_bytes" : 0,
+          "norms_memory_in_bytes" : 0,
+          "doc_values_memory_in_bytes" : 0,
+          "index_writer_memory_in_bytes" : 0,
+          "index_writer_max_memory_in_bytes" : 0,
+          "version_map_memory_in_bytes" : 0,
+          "fixed_bit_set_memory_in_bytes" : 0
+        },
+        "translog" : {
+          "operations" : 0,
+          "size_in_bytes" : 0
+        },
+        "suggest" : {
+          "total" : 0,
+          "time_in_millis" : 0,
+          "current" : 0
+        },
+        "request_cache" : {
+          "memory_size_in_bytes" : 0,
+          "evictions" : 0,
+          "hit_count" : 0,
+          "miss_count" : 0
+        },
+        "recovery" : {
+          "current_as_source" : 0,
+          "current_as_target" : 0,
+          "throttle_time_in_millis" : 0
+        }
+      },
+      "os" : {
+        "timestamp" : 1459467547007,
+        "load_average" : 2.67333984375,
+        "mem" : {
+          "total_in_bytes" : 17179869184,
+          "free_in_bytes" : 746893312,
+          "used_in_bytes" : 16432975872,
+          "free_percent" : 4,
+          "used_percent" : 96
+        },
+        "swap" : {
+          "total_in_bytes" : 1073741824,
+          "free_in_bytes" : 1073741824,
+          "used_in_bytes" : 0
+        }
+      },
+      "process" : {
+        "timestamp" : 1459467547007,
+        "open_file_descriptors" : 258,
+        "max_file_descriptors" : 10240,
+        "cpu" : {
+          "percent" : 0,
+          "total_in_millis" : 8580
+        },
+        "mem" : {
+          "total_virtual_in_bytes" : 5244633088
+        }
+      },
+      "jvm" : {
+        "timestamp" : 1459467547007,
+        "uptime_in_millis" : 51129,
+        "mem" : {
+          "heap_used_in_bytes" : 26052720,
+          "heap_used_percent" : 2,
+          "heap_committed_in_bytes" : 259522560,
+          "heap_max_in_bytes" : 1037959168,
+          "non_heap_used_in_bytes" : 41476512,
+          "non_heap_committed_in_bytes" : 42942464,
+          "pools" : {
+            "young" : {
+              "used_in_bytes" : 9156176,
+              "max_in_bytes" : 286326784,
+              "peak_used_in_bytes" : 71630848,
+              "peak_max_in_bytes" : 286326784
+            },
+            "survivor" : {
+              "used_in_bytes" : 7619176,
+              "max_in_bytes" : 35782656,
+              "peak_used_in_bytes" : 8912888,
+              "peak_max_in_bytes" : 35782656
+            },
+            "old" : {
+              "used_in_bytes" : 9277368,
+              "max_in_bytes" : 715849728,
+              "peak_used_in_bytes" : 9765824,
+              "peak_max_in_bytes" : 715849728
+            }
+          }
+        },
+        "threads" : {
+          "count" : 72,
+          "peak_count" : 75
+        },
+        "gc" : {
+          "collectors" : {
+            "young" : {
+              "collection_count" : 4,
+              "collection_time_in_millis" : 49
+            },
+            "old" : {
+              "collection_count" : 1,
+              "collection_time_in_millis" : 12
+            }
+          }
+        },
+        "buffer_pools" : {
+          "direct" : {
+            "count" : 63,
+            "used_in_bytes" : 9969773,
+            "total_capacity_in_bytes" : 9969773
+          },
+          "mapped" : {
+            "count" : 0,
+            "used_in_bytes" : 0,
+            "total_capacity_in_bytes" : 0
+          }
+        }
+      },
+      "thread_pool" : {
+        "bulk" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "fetch_shard_started" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "fetch_shard_store" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "flush" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "force_merge" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "generic" : {
+          "threads" : 1,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 4,
+          "completed" : 81
+        },
+        "get" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "index" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "listener" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "management" : {
+          "threads" : 1,
+          "queue" : 0,
+          "active" : 1,
+          "rejected" : 0,
+          "largest" : 1,
+          "completed" : 3
+        },
+        "percolate" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "refresh" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "search" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "snapshot" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "suggest" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        },
+        "warmer" : {
+          "threads" : 0,
+          "queue" : 0,
+          "active" : 0,
+          "rejected" : 0,
+          "largest" : 0,
+          "completed" : 0
+        }
+      },
+      "fs" : {
+        "timestamp" : 1459467547007,
+        "total" : {
+          "total_in_bytes" : 239063433216,
+          "free_in_bytes" : 9278656512,
+          "available_in_bytes" : 9016512512
+        },
+        "data" : [ {
+          "path" : "/usr/local/var/elasticsearch/elasticsearch/nodes/1",
+          "mount" : "/ (/dev/disk0s2)",
+          "type" : "hfs",
+          "total_in_bytes" : 239063433216,
+          "free_in_bytes" : 9278656512,
+          "available_in_bytes" : 9016512512
+        } ]
+      },
+      "transport" : {
+        "server_open" : 13,
+        "rx_count" : 109,
+        "rx_size_in_bytes" : 19037,
+        "tx_count" : 108,
+        "tx_size_in_bytes" : 11627
+      },
+      "http" : {
+        "current_open" : 0,
+        "total_opened" : 0
+      },
+      "breakers" : {
+        "request" : {
+          "limit_size_in_bytes" : 415183667,
+          "limit_size" : "395.9mb",
+          "estimated_size_in_bytes" : 0,
+          "estimated_size" : "0b",
+          "overhead" : 1.0,
+          "tripped" : 0
+        },
+        "fielddata" : {
+          "limit_size_in_bytes" : 622775500,
+          "limit_size" : "593.9mb",
+          "estimated_size_in_bytes" : 0,
+          "estimated_size" : "0b",
+          "overhead" : 1.03,
+          "tripped" : 0
+        },
+        "parent" : {
+          "limit_size_in_bytes" : 726571417,
+          "limit_size" : "692.9mb",
+          "estimated_size_in_bytes" : 0,
+          "estimated_size" : "0b",
+          "overhead" : 1.0,
+          "tripped" : 0
+        }
+      },
+      "script" : {
+        "compilations" : 0,
+        "cache_evictions" : 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes issue #33
- Adds IsYellow and IsRed metrics
- Refactors `ElasticsearchAgent` so that there is a dedicated easily tested `ClusterStatsReporter` that's directly analogous to `NodeStatsReporter`
- Refactored complexity in creating `ElasticsearchAgent` out of constructor and into `ElasticsearchAgentFactory`
- Fixes failing unit test (dependency on locally running Elasticsearch)
- Adds cluster stats json fixture for 2.1.1 (previously only existed for node stats; updated node stats json to match cluster stats)
- Corrects unit test organization (everything was in services package)
