### PR TITLE
Allow for specifying protocol and API base path

### DIFF
--- a/config/plugin.json
+++ b/config/plugin.json
@@ -5,6 +5,7 @@
       "port" : 9200,
       "username": "",
       "password": "",
+      "_basePath": "Optional. API path on server. Default '/'. Rename to 'basePath' if you need to customize it",
       "_name": "Optional. By default loaded from elasticsearch. Rename to 'name' if you need to customize it"
     }
   ]

--- a/config/plugin.json
+++ b/config/plugin.json
@@ -5,6 +5,7 @@
       "port" : 9200,
       "username": "",
       "password": "",
+      "_protocol": "Optional. Default 'http'. Rename to 'protocol' and set to 'https' if needed.",
       "_basePath": "Optional. API path on server. Default '/'. Rename to 'basePath' if you need to customize it",
       "_name": "Optional. By default loaded from elasticsearch. Rename to 'name' if you need to customize it"
     }

--- a/src/main/java/me/snov/newrelic/elasticsearch/ElasticsearchAgentFactory.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/ElasticsearchAgentFactory.java
@@ -36,6 +36,10 @@ public class ElasticsearchAgentFactory extends AgentFactory {
             basePath = "";
         }
 
+        if (basePath.endsWith("/")) {
+            basePath = basePath.substring(0, basePath.length() - 1);
+        }
+
         try {
             ClusterStatsParser clusterStatsParser = new ClusterStatsParser(protocol, host, port.intValue(), basePath, username, password);
             String clusterName = name != null && name.length() > 0  ? name  : clusterStatsParser.request().cluster_name;

--- a/src/main/java/me/snov/newrelic/elasticsearch/ElasticsearchAgentFactory.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/ElasticsearchAgentFactory.java
@@ -17,6 +17,8 @@ public class ElasticsearchAgentFactory extends AgentFactory {
     @Override
     public Agent createConfiguredAgent(Map<String, Object> properties) throws ConfigurationException {
         String host = (String) properties.get("host");
+        String protocol = (String) properties.get("protocol");
+        String basePath = (String) properties.get("basePath");
         String username = (String) properties.get("username");
         String password = (String) properties.get("password");
         Long port = (Long) properties.get("port");
@@ -26,13 +28,21 @@ public class ElasticsearchAgentFactory extends AgentFactory {
             throw new ConfigurationException("'host' and 'port' must be specified. Do you have a 'config/plugin.json' file?");
         }
 
+        if (protocol == null) {
+            protocol = "http";
+        }
+
+        if (basePath == null) {
+            basePath = "";
+        }
+
         try {
-            ClusterStatsParser clusterStatsParser = new ClusterStatsParser(host, port.intValue(), username, password);
+            ClusterStatsParser clusterStatsParser = new ClusterStatsParser(protocol, host, port.intValue(), basePath, username, password);
             String clusterName = name != null && name.length() > 0  ? name  : clusterStatsParser.request().cluster_name;
             ElasticsearchAgent agent = new ElasticsearchAgent(clusterName);
 
             ClusterStatsReporter clusterStatsReporter = new ClusterStatsReporter(agent);
-            NodesStatsParser nodeStatsParser = new NodesStatsParser(host, port.intValue(), username, password);
+            NodesStatsParser nodeStatsParser = new NodesStatsParser(protocol, host, port.intValue(), basePath, username, password);
             NodesStatsReporter nodeStatsReporter = new NodesStatsReporter(agent);
             agent.configure(clusterStatsParser, clusterStatsReporter, nodeStatsParser, nodeStatsReporter);
 

--- a/src/main/java/me/snov/newrelic/elasticsearch/parsers/AbstractParser.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/parsers/AbstractParser.java
@@ -12,8 +12,6 @@ import java.net.URL;
 
 abstract class AbstractParser<T> {
 
-    protected static final String HTTP = "http";
-
     private final Class<T> typeParameterClass;
     private final URL url;
     private final Gson gson;

--- a/src/main/java/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParser.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/parsers/ClusterStatsParser.java
@@ -13,7 +13,7 @@ public class ClusterStatsParser extends AbstractParser<ClusterStats> {
         super(ClusterStats.class, null, null, null);
     }
 
-    public ClusterStatsParser(String host, int port, String username, String password) throws MalformedURLException {
-        super(ClusterStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS), username, password);
+    public ClusterStatsParser(String protocol, String host, int port, String basePath, String username, String password) throws MalformedURLException {
+        super(ClusterStats.class, new URL(protocol, host, port, basePath + URL_CLUSTER_STATS), username, password);
     }
 }

--- a/src/main/java/me/snov/newrelic/elasticsearch/parsers/NodesStatsParser.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/parsers/NodesStatsParser.java
@@ -13,7 +13,7 @@ public class NodesStatsParser extends AbstractParser<NodesStats> {
         super(NodesStats.class, null, null, null);
     }
 
-    public NodesStatsParser(String host, int port, String username, String password) throws MalformedURLException {
-        super(NodesStats.class, new URL(HTTP, host, port, URL_CLUSTER_STATS), username, password);
+    public NodesStatsParser(String protocol, String host, int port, String basePath, String username, String password) throws MalformedURLException {
+        super(NodesStats.class, new URL(protocol, host, port, basePath + URL_CLUSTER_STATS), username, password);
     }
 }


### PR DESCRIPTION
I work in an environment where the ElasticSearch API is using HTTPS and its base path is /elasticsearch so both of these improvements are needed.  I thought it might be useful for others too.