### PR TITLE
changing bulk to write, since es6.3.0 thread_pool doesn't have bulk key

### DIFF
--- a/src/main/java/me/snov/newrelic/elasticsearch/reporters/NodesStatsReporter.java
+++ b/src/main/java/me/snov/newrelic/elasticsearch/reporters/NodesStatsReporter.java
@@ -186,20 +186,20 @@ public class NodesStatsReporter {
                         nodeStats.thread_pool.merge.rejected);
             }
 
-            // Bulk
-            // Component/V1/NodeStats/ThreadPool/Bulk/Completed/*
-            reportNodeProcessedMetric("V1/NodeStats/ThreadPool/Bulk/Completed", "threads/second", nodeName,
-                    nodeStats.thread_pool.bulk.completed);
+            // Write
+            // Component/V1/NodeStats/ThreadPool/Write/Completed/*
+            reportNodeProcessedMetric("V1/NodeStats/ThreadPool/Write/Completed", "threads/second", nodeName,
+                    nodeStats.thread_pool.write.completed);
 
-            // Bulk: queue
-            // Component/V1/NodeStats/ThreadPool/Bulk/Queue/*
-            reportNodeMetric("V1/NodeStats/ThreadPool/Bulk/Queue", "threads", nodeName,
-                    nodeStats.thread_pool.bulk.queue);
+            // Write: queue
+            // Component/V1/NodeStats/ThreadPool/Write/Queue/*
+            reportNodeMetric("V1/NodeStats/ThreadPool/Write/Queue", "threads", nodeName,
+                    nodeStats.thread_pool.write.queue);
 
-            // Bulk: rejected
-            // Component/V1/NodeStats/ThreadPool/Bulk/Rejected/*
-            reportNodeProcessedMetric("V1/NodeStats/ThreadPool/Bulk/Rejected", "threads/second", nodeName,
-                    nodeStats.thread_pool.bulk.rejected);
+            // Write: rejected
+            // Component/V1/NodeStats/ThreadPool/Write/Rejected/*
+            reportNodeProcessedMetric("V1/NodeStats/ThreadPool/Write/Rejected", "threads/second", nodeName,
+                    nodeStats.thread_pool.write.rejected);
 
             // Warmer
             // Component/V1/NodeStats/ThreadPool/Warmer/Completed/*


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-threadpool.html

```
write
For single-document index/delete/update and bulk requests. Thread pool type is fixed with a size of # of available processors, queue_size of 200. The maximum size for this pool is 1 + # of available processors.
```